### PR TITLE
window scrolls to top when user goes to details screen

### DIFF
--- a/client/src/details-screen.js
+++ b/client/src/details-screen.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import DetailRow from './detail-row';
 
 let DetailsScreen = (props) => {
+    window.scrollTo(0, 0)
     return <div className="info-section-details-screen" >
             <DetailRow 
                 experience={props.experiencesArray.find(experience=>


### PR DESCRIPTION
Details screen previously would not start window at the top of the screen. Window now scrolls to the top when the details screen is accessed. @MitchGuth can you please review when you get a chance? Thank you!